### PR TITLE
SREX-1440 distinguish environments in generated sentry issues

### DIFF
--- a/src/SentryExporter.php
+++ b/src/SentryExporter.php
@@ -45,23 +45,26 @@ class SentryExporter
         if($this->useThrottling){
             sleep(1);
         }
-        foreach ($projectData as $project) {
-            $projectIssues = $this->getIssues($project);
-            if($this->useThrottling){
-                sleep(1);
-            }
-            foreach ($projectIssues as $issue) {
-                $gauges->add(
-                    Gauge::fromValue($issue->count)->withLabels(
-                        Label::fromNameAndValue('project_slug', $project->slug),
-                        Label::fromNameAndValue('project_name', $project->name),
-                        Label::fromNameAndValue('issue_logger', $issue->logger ?? 'unknown'),
-                        Label::fromNameAndValue('issue_type', $issue->type),
-                        Label::fromNameAndValue('issue_link', $issue->permalink),
-                        Label::fromNameAndValue('issue_level', $issue->level)
-                    )
-                );
-            }
+        foreach (array(prod, qa, staging) as $env)
+          foreach ($projectData as $project) {
+              $projectIssues = $this->getIssues($project, $env);
+              if($this->useThrottling){
+                  sleep(1);
+              }
+              foreach ($projectIssues as $issue) {
+                  $gauges->add(
+                      Gauge::fromValue($issue->count)->withLabels(
+                          Label::fromNameAndValue('project_slug', $project->slug),
+                          Label::fromNameAndValue('project_name', $project->name),
+                          Label::fromNameAndValue('issue_logger', $issue->logger ?? 'unknown'),
+                          Label::fromNameAndValue('issue_type', $issue->type),
+                          Label::fromNameAndValue('issue_link', $issue->permalink),
+                          Label::fromNameAndValue('issue_level', $issue->level)
+                          Label::fromNameAndValue('environment', $env)
+                      )
+                  );
+              }
+          }
         }
 
         HttpResponse::fromMetricCollections($gauges)->withHeader('Content-Type', 'text/plain; charset=utf-8')->respond();
@@ -70,9 +73,9 @@ class SentryExporter
     /**
      * @throws GuzzleException
      */
-    protected function getIssues(\stdClass $project): array
+    protected function getIssues(\stdClass $project, $env): array
     {
-        $response = $this->httpClient->request('GET', "projects/{$project->organization->slug}/{$project->slug}/issues/", $this->options);
+        $response = $this->httpClient->request('GET', "projects/{$project->organization->slug}/{$project->slug}/issues/?" . http_build_query([ 'environment' => $env ]), $this->options);
 
         return $this->getJson($response);
     }


### PR DESCRIPTION
for now, we'll make the assumptions that we are segreggating by the environment.

Sentry's api does not support fetching the tag details of the issues, so we cannot
dynamically generate the environment label from the response.

We'd have to iterate over each issue and call the fetch tag api in order to
achieve that. However, it'll be a serious performance hit if we did that, and
it's not really feasible with the volume of issues we have.
